### PR TITLE
Organizationのアイコンが表示されるように

### DIFF
--- a/models/org.go
+++ b/models/org.go
@@ -76,6 +76,7 @@ func GetUserOrgsList(user *user_model.User) ([]*MinimalOrg, error) {
 	for i, orgCount := range orgCounts {
 		orgCount.Organization.NumRepos = orgCount.OrgCount
 		orgs[i] = &orgCount.Organization
+		orgs[i].Type = user_model.UserTypeOrganization
 	}
 
 	return orgs, nil


### PR DESCRIPTION
dbからorganizationを取得して，`Organization`型にキャストする際に，Type(userかorganizationかを区別するenum)が指定されておらず，すべてuser扱いになっていたので直した。